### PR TITLE
Fix for  vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "node": ">=0.8.0"
     },
     "dependencies": {
-        "request":"2.11.x"
+        "request":"2.74.0"
     },
     "devDependencies": {
         "jasmine-node": "1.14.5"


### PR DESCRIPTION
node-phonegap-build-api currently has a 1 vulnerable dependency paths, introducing 1 different types of known vulnerabilities.

This PR fixes vulnerable dependency, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/phonegap/node-phonegap-build-api) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix  the vulnerability.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)